### PR TITLE
Add querystring support.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ The options are the same options as express uses in `res.cookie(name, value. opt
 Set the change language URL. Lets say that you set the value to `/languages/{language}` in your configurations. If you visit with your browser the URL path `/languages/en-US`. It will change your language cookie value to `en-US`. It will redirect back to the origin URL if you send a referrer header and default to `/` if it don't send a referrer header.
 
 #### queryName (optional) \{Object\}
-You can optionally set the language using a query string. This option allows you to set the name of the query parameter that triggers the language setting.
+You can optionally set the language using a query string. This option allows you to set the name of the query parameter that triggers the language setting. The default value is `language`.
 
 ```js
 var middleware = requestLangauge({

--- a/README.md
+++ b/README.md
@@ -90,6 +90,19 @@ The options are the same options as express uses in `res.cookie(name, value. opt
 ##### cookie.url (optional)
 Set the change language URL. Lets say that you set the value to `/languages/{language}` in your configurations. If you visit with your browser the URL path `/languages/en-US`. It will change your language cookie value to `en-US`. It will redirect back to the origin URL if you send a referrer header and default to `/` if it don't send a referrer header.
 
+#### queryName (optional) \{Object\}
+You can optionally set the language using a query string. This option allows you to set the name of the query parameter that triggers the language setting.
+
+```js
+var middleware = requestLangauge({
+  languages: ['en-US', 'zh-CN'],
+  queryName: 'locale', // ?locale=zh-CN will set the language to 'zh-CN'
+  cookie: {
+    name: 'language'
+  }
+});
+```
+
 #### localizations (optional) {Function}
 Set the [L10ns][] `requireLocalizations(language)` function. The right language tag will be used and automatically figured out by `request-language`. [L10ns'][L10ns] `l()` function will be accessible through express' `req.localizations`. You also need to set a scoped `l` variable before usage, otherwise [L10ns][] can't update localization keys through code traversal:
 

--- a/index.js
+++ b/index.js
@@ -74,8 +74,9 @@ module.exports = function(props) {
     var queryName = props.queryName || 'language';
     var queryLanguage = req.query[queryName];
 
-    if(typeof queryLanguage === 'string' && queryLanguage.length > 1) {
-      set(props, req, language);
+    if(typeof queryLanguage === 'string' && queryLanguage.length > 1 &&
+        props.languages.indexOf(queryLanguage) !== -1) {
+      set(props, req, queryLanguage);
       req.cookies[props.cookie.name] = queryLanguage;
       res.cookie(props.cookie.name, queryLanguage, props.cookie.options);
       return next();

--- a/index.js
+++ b/index.js
@@ -71,6 +71,16 @@ module.exports = function(props) {
 
   return function(req, res, next) {
     var language;
+    var queryName = props.queryName || 'language';
+    var queryLanguage = req.query[queryName];
+
+    if(typeof queryLanguage === 'string' && queryLanguage.length > 1) {
+      set(props, req, language);
+      req.cookies[props.cookie.name] = queryLanguage;
+      res.cookie(props.cookie.name, queryLanguage, props.cookie.options);
+      return next();
+    }
+
     if(typeof props.cookie !== 'undefined') {
       if(typeof props.cookie.url === 'string') {
         changeLanguageURL.index = 0;

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "cookie-parser": "^1.3.4",
     "eslint": "1.10.3",
     "express": "^4.11.2",
+    "lodash": "3.10.1",
     "mocha": "^2.1.0",
     "sinon": "^1.12.2",
     "sinon-chai": "^2.7.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Figure out a request's language tag by parsing Accept-Language header and stored cookies.",
   "main": "index.js",
   "scripts": {
-    "test": "bin/test"
+    "pretest": "eslint .",
+    "test": "bin/test",
+    "watch": "watch 'clear && npm run -s test' ."
   },
   "repository": {
     "type": "git",
@@ -28,9 +30,11 @@
   "devDependencies": {
     "chai": "^2.0.0",
     "cookie-parser": "^1.3.4",
+    "eslint": "1.10.3",
     "express": "^4.11.2",
     "mocha": "^2.1.0",
     "sinon": "^1.12.2",
-    "sinon-chai": "^2.7.0"
+    "sinon-chai": "^2.7.0",
+    "watch": "0.17.1"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -7,6 +7,7 @@ var sinon = require('sinon');
 var chai = require('chai');
 var expect = require('chai').expect;
 var sinonChai = require('sinon-chai');
+var assign = require('lodash/object/assign');
 var spy = sinon.spy;
 var stub = sinon.stub;
 var noop = function() {};
@@ -34,7 +35,7 @@ function getRequest(acceptLanguage, storedLanguage) {
     acceptLanguage = options.acceptLanguage;
   }
 
-  return Object.assign({
+  return assign({
     locals: {},
     headers: {
       'accept-langauge': acceptLanguage

--- a/test/test.js
+++ b/test/test.js
@@ -300,7 +300,7 @@ describe('request-language', function() {
 
     middleware(req, res, next);
     expect(req.cookies.language).not.to.equal('zh-CN');
-    // expect(req.language).not.to.equal('zh-CN');
+    expect(req.language).not.to.equal('zh-CN');
   });
 
   it('should be able to use a custom query string name', function() {

--- a/test/test.js
+++ b/test/test.js
@@ -266,7 +266,7 @@ describe('request-language', function() {
   });
 
   it('should set the language requested in the query string', function() {
-    var middleware = requestLangauge({
+    var middleware = requestLanguage({
       languages: ['en-US', 'zh-CN'],
       cookie: {
         name: 'language'
@@ -281,10 +281,30 @@ describe('request-language', function() {
 
     middleware(req, res, next);
     expect(req.cookies.language).to.equal('zh-CN');
+    expect(req.language).to.equal('zh-CN');
+  });
+
+  it('should not set unsupported language from query string', function() {
+    var middleware = requestLanguage({
+      languages: ['en-US'],
+      cookie: {
+        name: 'language'
+      }
+    });
+    var req = getRequest({
+      acceptLanguage: 'en-US;q=1',
+      query: {
+        language: 'zh-CN'
+      }
+    });
+
+    middleware(req, res, next);
+    expect(req.cookies.language).not.to.equal('zh-CN');
+    // expect(req.language).not.to.equal('zh-CN');
   });
 
   it('should be able to use a custom query string name', function() {
-    var middleware = requestLangauge({
+    var middleware = requestLanguage({
       languages: ['en-US', 'zh-CN'],
       queryName: 'locale',
       cookie: {
@@ -300,5 +320,6 @@ describe('request-language', function() {
 
     middleware(req, res, next);
     expect(req.cookies.language).to.equal('zh-CN');
+    expect(req.language).to.equal('zh-CN');
   });
 });


### PR DESCRIPTION
Adds a new `queryName` option to customize the name of the query used to change the language.
