### PR TITLE
Allow use of query string functionality without cookies.

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,8 +77,10 @@ module.exports = function(props) {
     if(typeof queryLanguage === 'string' && queryLanguage.length > 1 &&
         props.languages.indexOf(queryLanguage) !== -1) {
       set(props, req, queryLanguage);
-      req.cookies[props.cookie.name] = queryLanguage;
-      res.cookie(props.cookie.name, queryLanguage, props.cookie.options);
+      if(typeof props.cookie !== 'undefined') {
+        req.cookies[props.cookie.name] = queryLanguage;
+        res.cookie(props.cookie.name, queryLanguage, props.cookie.options);
+      }
       return next();
     }
 

--- a/test/test.js
+++ b/test/test.js
@@ -371,4 +371,19 @@ describe('request-language', function() {
     response.clearCookie.should.have.been.calledWith('language');
     expect(req.language).to.equal(defaultLanguage);
   });
+
+  it('should set language from query string if cookie options are not specified', function () {
+    var middleware = requestLanguage({
+      languages: ['en-US', 'zh-CN']
+    });
+    var req = getRequest({
+      acceptLanguage: 'en-US;q=1',
+      query: {
+        language: 'zh-CN'
+      }
+    });
+
+    middleware(req, res, next);
+    expect(req.language).to.equal('zh-CN');
+  });
 });


### PR DESCRIPTION
At present, if the query string for "language" is supplied without specifying cookie options, the request fails with `TypeError: Cannot read property 'name' of undefined`.

This commit adds a check so that we don't use cookie functionality when cookie options are not supplied.
