### PR TITLE
fix: error TS6137: Cannot import type declaration files. Consider importing 'express' instead of '@types/express'

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 
-import * as e from '@types/express';
+import * as e from 'express';
 
 declare namespace ExpressRequestLanguage {
     interface Cookie {


### PR DESCRIPTION
for more info see https://github.com/Microsoft/TypeScript/issues/16472